### PR TITLE
Add support for undocumented 404 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,12 +126,13 @@ Note that the sort string appears to be case sensitive and must currently use th
 
 ## Errors
 
-In the [documentation](https://docs.planhat.com/), Planhat identifies the following returned errors.  These are provided as constants so that you may check against them:
+In the [documentation](https://docs.planhat.com/), Planhat identifies the following returned errors. Additionally, Planhat returns an undocumented error (404) when an entity is not found. These are provided as constants so that you may check against them:
 
 | Code | Error                | Constant           |
 |------|----------------------|--------------------|
 | 400  | Bad Request          | `ErrBadRequest`    |
 | 401  | Unauthorized Request | `ErrUnauthorized`  |
+| 404  | Not Found            | `ErrNotFound`      |
 | 403  | Forbidden            | `ErrForbidden`     |
 | 500  | Internal Error       | `ErrInternalError` |
 

--- a/errors.go
+++ b/errors.go
@@ -13,6 +13,7 @@ const (
 	ErrBadRequest        = Err("planhat: bad request")
 	ErrUnauthorized      = Err("planhat: unauthorized request")
 	ErrForbidden         = Err("planhat: forbidden")
+	ErrNotFound          = Err("planhat: not found")
 	ErrInternalError     = Err("planhat: internal error")
 	ErrUnknown           = Err("planhat: unexpected error occurred")
 	ErrMissingTenantUUID = Err("planhat: missing required tenant uuid for this request")

--- a/planhat.go
+++ b/planhat.go
@@ -155,6 +155,8 @@ func (c *Client) makeRequest(ctx context.Context, req *http.Request, v interface
 			planhatErr = ErrUnauthorized
 		case 403:
 			planhatErr = ErrForbidden
+		case 404:
+			planhatErr = ErrNotFound
 		case 500:
 			planhatErr = ErrInternalError
 		default:


### PR DESCRIPTION
Planhat returns a 404 HTTP response when the entity is not found. We've asked them to either fix or document that but this patch adds support for the undocumented response (found when trying to fetch a company by source id). 